### PR TITLE
Add notion-blog-demo links to HACKATHON_DEMO_README.md

### DIFF
--- a/HACKATHON_DEMO_README.md
+++ b/HACKATHON_DEMO_README.md
@@ -15,6 +15,7 @@ Model Context Protocol (MCP) is an open standard that enables AI models to secur
 **Start with these working examples:**
 - **[Basic MCP Integration](https://github.com/All-Hands-AI/agent-sdk/blob/main/examples/07_mcp_integration.py)**: Fetch MCP + Repomix MCP for web content and code analysis
 - **[OAuth MCP Integration](https://github.com/All-Hands-AI/agent-sdk/blob/main/examples/08_mcp_with_oauth.py)**: Notion MCP with OAuth authentication
+- **[Notion Blog Demo](https://github.com/jamiechicago312/agent-sdk/tree/ai-agent-hackathon-demo/examples/notion-blog-demo)**: Complete hackathon demo showing Notion MCP integration for automated blog generation
 - **[All Examples Directory](https://github.com/All-Hands-AI/agent-sdk/tree/main/examples)**: Complete collection of SDK usage patterns
 
 Here are compelling ways to integrate OpenHands SDK with MCP servers for your hackathon project:
@@ -285,6 +286,7 @@ conversation.run()
 ### Community Resources:
 - [Awesome MCP Servers](https://github.com/wong2/awesome-mcp-servers)
 - [MCP Examples and Tutorials](https://modelcontextprotocol.io/examples)
+- [Notion Blog Demo](https://github.com/jamiechicago312/agent-sdk/tree/ai-agent-hackathon-demo/examples/notion-blog-demo) - Complete hackathon example with setup guide
 - [OpenHands Community Slack](https://all-hands.dev/joinslack)
 
 ### Example MCP Servers to Try:


### PR DESCRIPTION
## Summary

This PR adds links to the notion-blog-demo example in the HACKATHON_DEMO_README.md file as requested in issue #9.

## Changes Made

- Added link to notion-blog-demo in the "Integration Options" section alongside other working examples
- Added link to notion-blog-demo in the "Community Resources" section for easy discovery
- Both links point to the complete hackathon demo with setup guide

## Links Added

- **Integration Options**: Added as a working example showing "Complete hackathon demo showing Notion MCP integration for automated blog generation"
- **Community Resources**: Added as a community resource with description "Complete hackathon example with setup guide"

## Testing

- Verified that the notion-blog-demo directory exists at the specified path
- Confirmed the links point to the correct branch (ai-agent-hackathon-demo)
- Checked that the additions are positioned logically within the document structure

Fixes #9

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/03b18131f14f41149cc540cafc615952)